### PR TITLE
Fix list command names in docs & help

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You can check that the plugin is available to FFWD using the **--plugins**
 command.
 
 ```bash
-$ ffwd --list-plugins
+$ ffwd --plugins
 Loaded Plugins:
   Plugin 'log'
     Source: from gem: ffwd-<version>

--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -20,7 +20,7 @@ file.
     :content_type: "application/json"
 ```
 
-To list all availble schemas and content types, use **ffwd --list-schemas**.
+To list all availble schemas and content types, use **ffwd --schemas**.
 
 This assumes that *my-schema-v01* is provided by a component which has been
 loaded.

--- a/docs/writing-plugins.md
+++ b/docs/writing-plugins.md
@@ -26,10 +26,10 @@ Adding this file to lib/ffwd/plugin/foo.rb will make FFWD automatically
 discover it.
 
 You can try this in the **ffwd** project and then test it with
-```bin/ffwd --list-plugins```.
+```bin/ffwd --plugins```.
 
 ```bash
-$ bin/ffwd --list-plugins
+$ bin/ffwd --plugins
 ```
 
 Done right this should list your newly created plugin among the list of

--- a/lib/ffwd.rb
+++ b/lib/ffwd.rb
@@ -209,7 +209,7 @@ module FFWD
     puts ""
     puts "  2) Are your plugins loaded?"
     puts "  Check with:"
-    puts "    ffwd -c .. --list-plugins"
+    puts "    ffwd -c .. --plugins"
     puts ""
     puts "  3) Did any errors happen when loading the plugins?"
     puts "  Check with:"


### PR DESCRIPTION
Update the docs to reflect the fact that --list-schemas and --list-plugins
have been renamed to --schemas and --plugins, respectively.
