### PR TITLE
JSON inputs can override time

### DIFF
--- a/lib/ffwd/plugin/json/connection.rb
+++ b/lib/ffwd/plugin/json/connection.rb
@@ -27,6 +27,7 @@ module FFWD::Plugin::JSON
       ["description", :description],
       ["ttl", :ttl],
       ["tags", :tags],
+      ["time", :time],
       ["attributes", :attributes],
     ]
 
@@ -36,6 +37,7 @@ module FFWD::Plugin::JSON
       ["host", :host],
       ["value", :value],
       ["tags", :tags],
+      ["time", :time],
       ["attributes", :attributes]
     ]
 


### PR DESCRIPTION
It would be nice to allow this for other plugins as well.
