### PR TITLE
datadog: Use "what:" value as metric name

### DIFF
--- a/plugins/ffwd-datadog/lib/ffwd/plugin/datadog/utils.rb
+++ b/plugins/ffwd-datadog/lib/ffwd/plugin/datadog/utils.rb
@@ -35,8 +35,18 @@ module FFWD::Plugin::Datadog
     # make safe entry out of available information.
     def self.safe_entry entry
       host = entry[:host]
-      metric = entry[:name]
       tags = entry[:attributes]
+
+      what ||= entry.delete(:what)
+      what ||= entry.delete("what")
+
+      unless what.nil?
+        metric = what
+        tags = tags.merge({:ffwd_key => entry[:name]})
+      else
+        metric = entry[:name]
+      end
+
       {:host => host, :metric => safe_string(metric), :tags => safe_tags(tags)}
     end
 

--- a/plugins/ffwd-datadog/spec/ffwd/plugin/datadog/utils_spec.rb
+++ b/plugins/ffwd-datadog/spec/ffwd/plugin/datadog/utils_spec.rb
@@ -22,5 +22,11 @@ describe FFWD::Plugin::Datadog::Utils do
       ref = {:metric=>"name", :host => :host, :tags=>["foo:bar_baz"]}
       expect(described_class.safe_entry(entry)).to eq(ref)
     end
+
+    it "should use 'what' attribute as the datadog metric name" do
+      entry = {:name => :name, :host => :host, :attributes => {:foo => "bar baz"}, :what => "thing"}
+      ref = {:metric=>"thing", :host => :host, :tags=>["foo:bar_baz", "ffwd_key:#{:name}"]}
+      expect(described_class.safe_entry(entry)).to eq(ref)
+    end
   end
 end


### PR DESCRIPTION
This makes things jive better with Datadog's indexing and UI.
