### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ By doing this, the application generating the data becomes simpler to build,
 maintain, and configure since it doesn't have to know _where_ it is running.
 Only that ffwd is available on the loopback interface.
 
-This also provides benefits for simpler protocols, like [plaintext carbon](http://graphite.readthedocs.org/en/latest/feeding-carbon.html#the-plaintext-protocol),
+This also provides benefits for simpler protocols, like [plaintext carbon](https://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol),
 where this kind of information can become painful to represent in the limited
 structure available.
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
