### PR TITLE
reduce suggested receive_buffer_size

### DIFF
--- a/docs/basic-local-ffwd.md
+++ b/docs/basic-local-ffwd.md
@@ -28,7 +28,7 @@ $ gem install ffwd-protobuf
 ```bash
 :input:
   - :type: "protobuf"
-    :receive_buffer_size: 26214400
+    :receive_buffer_size: 2621440
 ```
 5- run FFWD:
 ```bash


### PR DESCRIPTION
The current recommendation for `receive_buffer_size` is `3.125 * 2^23`.

On macOS Sierra, the default max socket buffer size is `2^23`.
```
$ sysctl kern.ipc.maxsockbuf
kern.ipc.maxsockbuf: 8388608
```

When running in macOS with the recommended `receive_buffer_size`, we get the following:

```
I, [2017-02-02T10:12:43.273220 #98870]  INFO -- FFWD::Plugin::Protobuf: Setting receive buffer size to 26214400
W, [2017-02-02T10:12:43.273296 #98870]  WARN -- FFWD::Plugin::Protobuf: Bind on udp://localhost:19091 failed, retry #1 in 10000s: No buffer space available - setsockopt
/Library/Ruby/Gems/2.0.0/gems/ffwd-0.4.2/lib/ffwd/protocol/udp/bind.rb:72:in `block in initialize': undefined method `close' for #<FFWD::Plugin::Protobuf::InputUDP:0x007fbd54955b78> (NoMethodError)
	from /Library/Ruby/Gems/2.0.0/gems/ffwd-0.4.2/lib/ffwd/retrier.rb:58:in `call'
	from /Library/Ruby/Gems/2.0.0/gems/ffwd-0.4.2/lib/ffwd/retrier.rb:58:in `block in try_block'
	from /Library/Ruby/Gems/2.0.0/gems/ffwd-0.4.2/lib/ffwd/retrier.rb:57:in `each'
	from /Library/Ruby/Gems/2.0.0/gems/ffwd-0.4.2/lib/ffwd/retrier.rb:57:in `rescue in try_block'
	from /Library/Ruby/Gems/2.0.0/gems/ffwd-0.4.2/lib/ffwd/retrier.rb:53:in `try_block'
	from /Library/Ruby/Gems/2.0.0/gems/ffwd-0.4.2/lib/ffwd/retrier.rb:37:in `block in initialize'
	from /Library/Ruby/Gems/2.0.0/gems/ffwd-0.4.2/lib/ffwd/lifecycle.rb:51:in `call'
	from /Library/Ruby/Gems/2.0.0/gems/ffwd-0.4.2/lib/ffwd/lifecycle.rb:51:in `each'
	from /Library/Ruby/Gems/2.0.0/gems/ffwd-0.4.2/lib/ffwd/lifecycle.rb:51:in `start'
	from /Library/Ruby/Gems/2.0.0/gems/ffwd-0.4.2/lib/ffwd/lifecycle.rb:83:in `block in depend_on'
	from /Library/Ruby/Gems/2.0.0/gems/ffwd-0.4.2/lib/ffwd/lifecycle.rb:51:in `call'
	from /Library/Ruby/Gems/2.0.0/gems/ffwd-0.4.2/lib/ffwd/lifecycle.rb:51:in `each'
	from /Library/Ruby/Gems/2.0.0/gems/ffwd-0.4.2/lib/ffwd/lifecycle.rb:51:in `start'
	from /Library/Ruby/Gems/2.0.0/gems/ffwd-0.4.2/lib/ffwd/lifecycle.rb:83:in `block in depend_on'
	from /Library/Ruby/Gems/2.0.0/gems/ffwd-0.4.2/lib/ffwd/lifecycle.rb:51:in `call'
	from /Library/Ruby/Gems/2.0.0/gems/ffwd-0.4.2/lib/ffwd/lifecycle.rb:51:in `each'
	from /Library/Ruby/Gems/2.0.0/gems/ffwd-0.4.2/lib/ffwd/lifecycle.rb:51:in `start'
	from /Library/Ruby/Gems/2.0.0/gems/ffwd-0.4.2/lib/ffwd/core.rb:132:in `block in run'
	from /Library/Ruby/Gems/2.0.0/gems/eventmachine-1.0.4/lib/eventmachine.rb:187:in `call'
	from /Library/Ruby/Gems/2.0.0/gems/eventmachine-1.0.4/lib/eventmachine.rb:187:in `run_machine'
	from /Library/Ruby/Gems/2.0.0/gems/eventmachine-1.0.4/lib/eventmachine.rb:187:in `run'
	from /Library/Ruby/Gems/2.0.0/gems/ffwd-0.4.2/lib/ffwd/core.rb:128:in `run'
	from /Library/Ruby/Gems/2.0.0/gems/ffwd-0.4.2/lib/ffwd.rb:360:in `main'
	from /Library/Ruby/Gems/2.0.0/gems/ffwd-0.4.2/bin/ffwd:9:in `<top (required)>'
	from /usr/local/bin/ffwd:23:in `load'
	from /usr/local/bin/ffwd:23:in `<main>'
```

Unless there's a specific reason for picking `3.125 * 2^23`, we could change our recommendation to something smaller than `2^23`.